### PR TITLE
Add CakeAliasCategory attribute

### DIFF
--- a/Cake.Buns.ReportPortal/ReportPortalAliases.cs
+++ b/Cake.Buns.ReportPortal/ReportPortalAliases.cs
@@ -13,6 +13,7 @@ using LogLevel = Cake.Core.Diagnostics.LogLevel;
 
 namespace Cake.Buns.ReportPortal
 {
+    [CakeAliasCategory("Report Portal")]
     [CakeNamespaceImport("ReportPortal.Buns.Clean")]
     [CakeNamespaceImport("ReportPortal.Buns.Merge")]
     [CakeNamespaceImport("ReportPortal.Buns.Merge.Smart")]


### PR DESCRIPTION
Add attribute for Cake alias category which will list be used to list the aliases on the DSL reference page at https://cakebuild.net/dsl/ and on the addin detail page at https://cakebuild.net/extensions/cake-buns-reportportal/